### PR TITLE
Fix mro freetext

### DIFF
--- a/mroo/mro.html
+++ b/mroo/mro.html
@@ -89,7 +89,7 @@ Change size: <input id="fontFSSizeSlider" type="range" min="12" max="100" step="
 oninput="document.getElementById('freeText').style.fontSize = this.value+'px'; document.getElementById('sizeFSIndicator').textContent=this.value+'px'"> &nbsp; <span id="sizeFSIndicator">24px</span></p>
 
 <div id="freeText" dir="ltr" lang="mro" contenteditable="true" title="Sample text." data-source="https://www.ohchr.org/sites/default/files/UDHR/Documents/UDHR_Translations/mro.pdf">
-<p onMouseUp="showtext('freeText')" data-translation="">𖩏𖩖𖩔𖩆𖩊 𖩗𖩖𖩊 𖩎𖩆𖩁 𖩋𖩖 𖩍𖩖𖩌… 𖩏𖩖𖩎𖩊 𖩏𖩆𖩔𖩆𖩊 𖩌𖩖 𖩐𖩓𖩆𖩎 𖩖𖩂𖩑𖩌 𖩎𖩖… 𖩌𖩍𖩖𖩁𖩐𖩖 𖩂𖩑𖩌 𖩎𖩖 𖩖𖩎𖩆𖩁 𖩀𖩑𖩖𖩏 𖩈𖩝𖩐 𖩐𖩖… 𖩏𖩖𖩔𖩆𖩊 𖩈𖩝𖩌𖩇𖩆𖩌𖩓𖩑𖩖𖩗 𖩌𖩖 𖩍𖩖𖩁 𖩔𖩓𖩊𖩏 𖩌𖩆𖩎𖩄𖩝𖩓 𖩈𖩝𖩆 𖩀𖩐𖩘𖩅 𖩐𖩓𖩆𖩁… 𖩍𖩖𖩁𖩔𖩊𖩏𖩌𖩆𖩎𖩄𖩝𖩓 𖩏𖩖𖩔𖩆𖩊 𖩈𖩝𖩌𖩇𖩆 𖩗𖩖𖩊 𖩀𖩔𖩆𖩎 𖩈𖩘𖩒 𖩌𖩖 𖩖𖩌𖩆𖩓 𖩎𖩊 𖩌𖩆𖩓𖩔𖩘 𖩀𖩘𖩌 𖩍𖩖𖩎𖩊 𖩆𖩁 𖩊𖩁 𖩌𖩖𖩁 𖩆𖩁𖩊𖩁𖩌𖩖𖩁 𖩈𖩖𖩄𖩖𖩅… 𖩆𖩁 𖩊𖩁 𖩌𖩖𖩁</p>
+<p onMouseUp="showtext('freeText')" data-translation="">𖩏𖩖𖩔𖩆𖩊 𖩗𖩖𖩊 𖩍𖩖𖩌 𖩎𖩆𖩁 𖩋𖩖 𖩍𖩖𖩌𖩯 𖩏𖩖𖩎𖩊 𖩏𖩖𖩔𖩆𖩊 𖩌𖩖 𖩐𖩓𖩆𖩎 𖩖𖩂𖩑𖩌 𖩎𖩖𖩯 𖩌𖩍𖩖𖩁𖩐𖩖 𖩂𖩑𖩌 𖩎𖩖 𖩖𖩎𖩆𖩁 𖩀𖩑𖩖𖩏 𖩈𖩝𖩐 𖩐𖩖𖩮 𖩏𖩖𖩔𖩆𖩊 𖩈𖩝𖩌𖩇𖩆 𖩌𖩓𖩑𖩖𖩗 𖩌𖩖 𖩍𖩖𖩁 𖩔𖩓𖩊𖩏 𖩌𖩆𖩎𖩄𖩝𖩓 𖩈𖩝𖩆 𖩀𖩐𖩘𖩅 𖩐𖩓𖩆𖩁𖩮\n𖩍𖩖𖩁𖩔𖩊𖩏 𖩌𖩆𖩎𖩄𖩝𖩓 𖩏𖩖𖩔𖩆𖩊 𖩈𖩝𖩌𖩇𖩆 𖩗𖩖𖩊 𖩀𖩔𖩆𖩎 𖩈𖩘𖩒 𖩌𖩖 𖩖𖩌𖩆𖩓 𖩎𖩊 𖩌𖩆𖩓 𖩅𖩖𖩌 𖩖𖩊 𖩌𖩆𖩓 𖩔𖩘 𖩍𖩖𖩎𖩊 𖩆𖩁 𖩊𖩁 𖩌𖩖𖩁 𖩆𖩁𖩊𖩁 𖩌𖩖𖩁 𖩈𖩖𖩄𖩖𖩅𖩯 𖩆𖩁 𖩊𖩁 𖩌𖩖𖩁 𖩘 𖩗𖩆𖩁 𖩍𖩝𖩁 𖩄𖩑𖩖𖩗 𖩅𖩊𖩂𖩯</p>
 </div>
 <details><summary class="instructions">Source</summary><p><a href="https://omniglot.com/writing/mro.htm">Omniglot</a></p></details>
 </section>


### PR DESCRIPTION
Same issue as described in https://github.com/googlefonts/lang/pull/100#issuecomment-1665974614:
This mro-Mroo free text sample likely comes from https://www.unicode.org/L2/L2011/11122-n4010-mro-danda.pdf and has wrong or missing characters. The last sentence is also complete in L2/11-122.