### PR TITLE
guru/pa: 0A74 changed in Unicode 11.0

### DIFF
--- a/guru/pa.html
+++ b/guru/pa.html
@@ -1829,12 +1829,12 @@ though this appears to be quite rare, eg.</p>
 
 <figure class="characterBox auto" data-cols="" data-notes="ek onkar,adi shakti">ੴ␣☬</figure>
 
-<p><span class="codepoint" translate="no"><span lang="pa">&#x0A74;</span> [<a href="/scripts/gurmukhi/block#char0A74"><span class="uname">U+0A74 GURMUKHI EK ONKAR</span></a>]</span> can have various different forms. Unicode classes it as a letter. The shape in the Unicode charts is highly stylised.</p>
+<p><span class="codepoint" translate="no"><span lang="pa">&#x0A74;</span> [<a href="/scripts/gurmukhi/block#char0A74"><span class="uname">U+0A74 GURMUKHI EK ONKAR</span></a>]</span> can have various different forms. Unicode classes it as a letter. The shape in Arial MS Unicode is highly stylised, most fonts shape it as digit one followed by a sign based on ura with a long upper tail.</p>
 
 
 <figure id="fig_ek_onkar" class="sideCaption">
 <img src="images/0A74.png" alt="" class="ex" lang="pa" style="height: 9rem;">
-<figcaption>The stylised shape of ek onkar in the Unicode chart<span class="trans"></span>.</figcaption>
+<figcaption>The stylised shape of ek onkar in Arial MS Unicode<span class="trans"></span>.</figcaption>
 </figure>
 
 <p>The other religious symbol, <span class="codepoint" translate="no"><span lang="pa">&#x262C;</span> [<a href="/scripts/gurmukhi/block#char262C"><span class="uname">U+262C ADI SHAKTI</span></a>]</span>, is encoded in Unicode's Miscellaneous Symbols block.</p>


### PR DESCRIPTION
After an error report in 2016 (http://www.unicode.org/L2/L2016/16123-pubrev.html\#Error_Reports), the glyph in the Unicode charts was changed to the simpler form (https://www.unicode.org/charts/PDF/Unicode-11.0/U110-0A00.pdf).