### PR TITLE
Typo fixes in arab/ur and arab/ur-details

### DIFF
--- a/arab/ur-details.html
+++ b/arab/ur-details.html
@@ -40,7 +40,7 @@ which is abbreviated with the symbol <span class="ex" dir="rtl" lang="ur">ھ</sp
 
 
 '\u{0602}': `
-<p>Used to indicate that a number is a footnote, eg. <span class="ex" dir="rtl" lang="ur">؎۵</span>. </p>
+<p>Used to indicate that a number is a footnote, eg. <span class="ex" dir="rtl" lang="ur">؂۵</span>. </p>
 <p>The number  sits above the symbol, although this is not a combining character. The marker should come before the number in logical order<span class="ed"><tt>u,380</tt>.</span></p>
 <p>Do not confuse this with <span class="codepoint"><span lang="ar" dir="rtl">&#x060E;</span> <a href="#char060E">[<span class="uname">U+060E ARABIC POETIC VERSE SIGN</span>]</a></span>.</p>
 `,

--- a/arab/ur.html
+++ b/arab/ur.html
@@ -3991,7 +3991,7 @@ is not used, and moreover is not even functional in some fonts. For example, it 
 
 <p>The alphabetic baseline is a strong feature of Arabic script on the whole, since characters tend to join there. The nastaliq style of the script, on the other hand, uses arrangements of joined glyphs that cascade downwards from right to left, and ressemble a strongly sloping baseline. See the examples in  <a class="figref">fig_baseline</a> and <a class="figref">fig_gpos</a>.</p>
 
-<p><a class="figref">fig_overlap</a> shows overlapping baselines in the Nafees Nastaliq font. (In the Awami and Noto fonts, there is no overlap for that text.)</p>
+<p><a class="figref">fig_overlap</a> shows overlapping baselines in the Awami Nastaliq font. (In the Nafees and Noto fonts, there is no overlap for that text.)</p>
 
 <p>This cascading effect can lead to a need for quite large line height settings, compared to many other orthographies.</p>
 

--- a/arab/ur.html
+++ b/arab/ur.html
@@ -4057,7 +4057,7 @@ is not used, and moreover is not even functional in some fonts. For example, it 
 
 <p class="instructions">See <a class="secref">inlinenotes</a> for purely inline annotations, such as ruby or warichu. This section is about annotation systems that separate the reference marks and the content of the notes.</p>
 
-<p><span class="ch">؂</span> is used to indicate that a number is a reference to a footnote. The number sits above the symbol, although this is not a combining character. The marker should come before the number in logical order, eg. <span class="ch">؎۵</span>.</p>
+<p><span class="ch">؂</span> is used to indicate that a number is a reference to a footnote. The number sits above the symbol, although this is not a combining character. The marker should come before the number in logical order, eg. <span class="ch">؂۵</span>.</p>
 <p>(Note that, although it looks very similar, this is not the same character as <span class="ch">؎</span>.)</p>
 </section>
 </section>


### PR DESCRIPTION
This PR fixes a few typos:

* In arab/ur and arab/ur-details: Examples of U+0602 ARABIC FOOTNOTE MARKER were using U+060E ARABIC POETIC VERSE SIGN.
* In arab/ur: Figure 17 shows text in Awami Nastaliq font, but its reference in the "Baselines, line height, etc." section erroneously stated it was Nafees Nastaliq.